### PR TITLE
[Backport] Reload cart totals when cart data changes

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/cart/estimate-service.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/cart/estimate-service.js
@@ -19,7 +19,7 @@ define([
         /**
          * Estimate totals for shipping address and update shipping rates.
          */
-        estimateTotalsAndUpdateRates = function() {
+        estimateTotalsAndUpdateRates = function () {
             var type = quote.shippingAddress().getType();
 
             if (
@@ -58,14 +58,14 @@ define([
         /**
          * Estimate totals for shipping address.
          */
-        estimateTotalsShipping = function() {
+        estimateTotalsShipping = function () {
             totalsDefaultProvider.estimateTotals(quote.shippingAddress());
         },
 
         /**
          * Estimate totals for billing address.
          */
-        estimateTotalsBilling = function() {
+        estimateTotalsBilling = function () {
             var type = quote.billingAddress().getType();
 
             if (quote.isVirtual()) {

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/cart/estimate-service.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/cart/estimate-service.js
@@ -14,55 +14,70 @@ define([
     'use strict';
 
     var rateProcessors = [],
-        totalsProcessors = [];
+        totalsProcessors = [],
 
-    quote.shippingAddress.subscribe(function () {
-        var type = quote.shippingAddress().getType();
+        /**
+         * Estimate totals for shipping address and update shipping rates.
+         */
+        estimateTotalsAndUpdateRates = function() {
+            var type = quote.shippingAddress().getType();
 
-        if (
-            quote.isVirtual() ||
-            window.checkoutConfig.activeCarriers && window.checkoutConfig.activeCarriers.length === 0
-        ) {
-            // update totals block when estimated address was set
-            totalsProcessors['default'] = totalsDefaultProvider;
-            totalsProcessors[type] ?
-                totalsProcessors[type].estimateTotals(quote.shippingAddress()) :
-                totalsProcessors['default'].estimateTotals(quote.shippingAddress());
-        } else {
-            // check if user data not changed -> load rates from cache
-            if (!cartCache.isChanged('address', quote.shippingAddress()) &&
-                !cartCache.isChanged('cartVersion', customerData.get('cart')()['data_id']) &&
-                cartCache.get('rates')
+            if (
+                quote.isVirtual() ||
+                window.checkoutConfig.activeCarriers && window.checkoutConfig.activeCarriers.length === 0
             ) {
-                shippingService.setShippingRates(cartCache.get('rates'));
+                // update totals block when estimated address was set
+                totalsProcessors['default'] = totalsDefaultProvider;
+                totalsProcessors[type] ?
+                    totalsProcessors[type].estimateTotals(quote.shippingAddress()) :
+                    totalsProcessors['default'].estimateTotals(quote.shippingAddress());
+            } else {
+                // check if user data not changed -> load rates from cache
+                if (!cartCache.isChanged('address', quote.shippingAddress()) &&
+                    !cartCache.isChanged('cartVersion', customerData.get('cart')()['data_id']) &&
+                    cartCache.get('rates')
+                ) {
+                    shippingService.setShippingRates(cartCache.get('rates'));
 
-                return;
+                    return;
+                }
+
+                // update rates list when estimated address was set
+                rateProcessors['default'] = defaultProcessor;
+                rateProcessors[type] ?
+                    rateProcessors[type].getRates(quote.shippingAddress()) :
+                    rateProcessors['default'].getRates(quote.shippingAddress());
+
+                // save rates to cache after load
+                shippingService.getShippingRates().subscribe(function (rates) {
+                    cartCache.set('rates', rates);
+                });
             }
+        },
 
-            // update rates list when estimated address was set
-            rateProcessors['default'] = defaultProcessor;
-            rateProcessors[type] ?
-                rateProcessors[type].getRates(quote.shippingAddress()) :
-                rateProcessors['default'].getRates(quote.shippingAddress());
+        /**
+         * Estimate totals for shipping address.
+         */
+        estimateTotalsShipping = function() {
+            totalsDefaultProvider.estimateTotals(quote.shippingAddress());
+        },
 
-            // save rates to cache after load
-            shippingService.getShippingRates().subscribe(function (rates) {
-                cartCache.set('rates', rates);
-            });
-        }
-    });
-    quote.shippingMethod.subscribe(function () {
-        totalsDefaultProvider.estimateTotals(quote.shippingAddress());
-    });
-    quote.billingAddress.subscribe(function () {
-        var type = quote.billingAddress().getType();
+        /**
+         * Estimate totals for billing address.
+         */
+        estimateTotalsBilling = function() {
+            var type = quote.billingAddress().getType();
 
-        if (quote.isVirtual()) {
-            // update totals block when estimated address was set
-            totalsProcessors['default'] = totalsDefaultProvider;
-            totalsProcessors[type] ?
-                totalsProcessors[type].estimateTotals(quote.billingAddress()) :
-                totalsProcessors['default'].estimateTotals(quote.billingAddress());
-        }
-    });
+            if (quote.isVirtual()) {
+                // update totals block when estimated address was set
+                totalsProcessors['default'] = totalsDefaultProvider;
+                totalsProcessors[type] ?
+                    totalsProcessors[type].estimateTotals(quote.billingAddress()) :
+                    totalsProcessors['default'].estimateTotals(quote.billingAddress());
+            }
+        };
+
+    quote.shippingAddress.subscribe(estimateTotalsAndUpdateRates);
+    quote.shippingMethod.subscribe(estimateTotalsShipping);
+    quote.billingAddress.subscribe(estimateTotalsBilling);
 });

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/cart/estimate-service.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/cart/estimate-service.js
@@ -80,4 +80,5 @@ define([
     quote.shippingAddress.subscribe(estimateTotalsAndUpdateRates);
     quote.shippingMethod.subscribe(estimateTotalsShipping);
     quote.billingAddress.subscribe(estimateTotalsBilling);
+    customerData.get('cart').subscribe(estimateTotalsShipping);
 });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/estimate-service.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/cart/estimate-service.test.js
@@ -143,5 +143,10 @@ define([
             });
             expect(mocks['Magento_Checkout/js/model/cart/totals-processor/default'].estimateTotals).toHaveBeenCalled();
         });
+
+        it('test subscribe when cart data was changed', function () {
+            mocks['Magento_Customer/js/customer-data'].get('cart')({ data_id: 2 });
+            expect(mocks['Magento_Checkout/js/model/cart/totals-processor/default'].estimateTotals).toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18700
> Reload cart totals when cart data changes

### Description (*)
When cart data changes on cart view, the totals need to be reloaded. For example, when the qty changes, the totals of the cart data change as well. 

This normally doesn't happen in default Magento, because cart mutations reload the entire page. I stumbled upon this problem when creating an extension that allows the customer to change qty without reloading the page. 

### Manual testing scenarios (*)
I can't really provide steps to reproduce my situation, because core Magento doesn't do javascript cart mutations on the cart view. But, when adding items to cart, the totals should be rendered properly. This change shouldn't affect the usual totals estimation. So here you go:
- Add an item to the cart.
- The totals should be initialized.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
